### PR TITLE
Fixed #125: Divs no longer span the whole line

### DIFF
--- a/pixel.css
+++ b/pixel.css
@@ -1,5 +1,6 @@
 /*Stylizing Pixel*/
 .layer-div {
+  display: inline-block;
   position: relative;
 }
 

--- a/source/ui-manager.js
+++ b/source/ui-manager.js
@@ -232,12 +232,12 @@ export class UIManager
             };
         };
 
-
         // Backwards because layers' display should be the same as visual "z-index" priority (depth)
         for (var index = layers.length - 1; index >= 0; index--)
         {
             let layer = layers[index],
                 layerDiv = document.createElement("div"),
+                linebreak = document.createElement("br"),
                 colourDiv = document.createElement("div"),
                 layerName = document.createElement("input"),
                 layerOptionsDiv = document.createElement("div"),
@@ -280,6 +280,7 @@ export class UIManager
             layerDiv.appendChild(colourDiv);
             layerDiv.appendChild(layerActivationDiv);
             layersViewDiv.appendChild(layerDiv);
+            layersViewDiv.appendChild(linebreak);
         }
         document.body.appendChild(layersViewDiv);
 


### PR DESCRIPTION
Line breaks are added in the `ui-manager.js` and the `css` file treats
the layer elements as in-line elements. Now layers cannot be dragged
from the white space aside it.
Note: layer `div`s are still text boxes.
Closes #125.