### PR TITLE
Closes #113: unsubscribe keyboard when renaming

### DIFF
--- a/source/pixel.js
+++ b/source/pixel.js
@@ -366,19 +366,24 @@ export default class PixelPlugin
         }
     }
 
-    editLayerName (e, layerName)
+    editLayerName (e, layerName, layerDiv)
     {
         const RETURN_KEY = 13;
 
         // TODO: Listen for changes when clicked outside of LayerName
         // TODO: Unsubscribe from other keyboard listeners
         // TODO: Disable drag for layers
+        this.unsubscribeFromKeyboardEvents();
+        layerDiv.setAttribute("draggable", "false");
+
         let key = e.which || e.keyCode;
         if (key === RETURN_KEY)
         {
             // TODO: Subscribe to other keyboard listeners
+            this.subscribeToKeyboardEvents();
             this.layers[this.selectedLayerIndex].updateLayerName(layerName.value);
             layerName.setAttribute("readonly", "true");
+            layerDiv.setAttribute("draggable", "true");
         }
     }
 

--- a/source/tools.js
+++ b/source/tools.js
@@ -8,8 +8,8 @@ export class Tools
                 brush: "brush",
                 rectangle: "rectangle",
                 grab: "grab",
-                eraser: "eraser"
-                //select: "select"
+                eraser: "eraser",
+                select: "select"
 
             };
         this.currentTool = this.type.brush;

--- a/source/ui-manager.js
+++ b/source/ui-manager.js
@@ -213,7 +213,7 @@ export class UIManager
         {
             colourDiv.addEventListener("click", () => { this.pixelInstance.displayColourOptions(); });
             layerActivationDiv.addEventListener("click", () => { this.pixelInstance.toggleLayerActivation(layer, layerActivationDiv); });
-            layerName.addEventListener('keypress', (e) => { this.pixelInstance.editLayerName(e, layerName); });
+            layerName.addEventListener('keypress', (e) => { this.pixelInstance.editLayerName(e, layerName, layerDiv); });
             layerOptionsDiv.onclick = () => { this.pixelInstance.displayLayerOptions(layer, layerOptionsDiv); };
 
             layerDiv.ondrag = (evt) => { this.pixelInstance.dragging(evt); };


### PR DESCRIPTION
Unsubscribe and resubscribe from keyboard event listener when renaming
layers so that tools are not selected while renaming layers.