### PR TITLE
Completes #160: opacity slider fixed

### DIFF
--- a/source/ui-manager.js
+++ b/source/ui-manager.js
@@ -125,7 +125,7 @@ export class UIManager
             opacitySlider = document.createElement("input"),
             text = document.createTextNode("Opacity");
 
-        br.setAttribute("id", "opacity-br");
+        br.setAttribute("id", "opacity-br-" + layer.layerId);
 
         opacityDiv.setAttribute("class", "layer-tool");
         opacityDiv.setAttribute("id", "layer-" + layer.layerId + "-opacity-tool");
@@ -159,7 +159,7 @@ export class UIManager
     destroyOpacitySlider (layer)
     {
         let opacitySlider = document.getElementById("layer-" + layer.layerId + "-opacity-tool"),
-            br = document.getElementById("opacity-br");
+            br = document.getElementById("opacity-br-" + layer.layerId);
         opacitySlider.parentElement.removeChild(opacitySlider);
         br.parentElement.removeChild(br);
     }


### PR DESCRIPTION
Opacity slider no longer re-snaps to the side of the layer when another
layer’s opacity slider is hidden. The code was recognizing the wrong
`br` as the one to remove in `destroyOpacitySlider`.