### PR TITLE
Layer order hotkeys

### DIFF
--- a/pixel.css
+++ b/pixel.css
@@ -471,3 +471,9 @@ button {
 .tutorial-image {
   width: 100%;
 }
+
+#tutorial-progress {
+  position: absolute;
+  right: 10px;
+  bottom: 60px;
+}

--- a/source/pixel.js
+++ b/source/pixel.js
@@ -372,12 +372,21 @@ export default class PixelPlugin
         switch (e.key.toLowerCase())
         {
             case "[":
-                if (e.ctrlKey || e.metaKey)
+                console.log(this.selectedLayerIndex);
+                if (this.selectedLayerIndex !== 0)
+                    this.reorderLayers(this.selectedLayerIndex, this.selectedLayerIndex - 1);
+                else
                 {
-                    //TODO: swap current layer and next lower layer, unless there is no lower layer
-                    //this.reorderLayers()
+                    //TODO: throw layer is already lowest layer exception
                 }
                 break;
+            case "]":
+                if (this.selectedLayerIndex !== this.layers.length - 1)
+                    this.reorderLayers(this.selectedLayerIndex, this.selectedLayerIndex + 1);
+                else
+                {
+                    //TODO: throw layer is already highest layer exception
+                }
             case "escape":
                 if (this.selection !== null)
                 {

--- a/source/tutorial.js
+++ b/source/tutorial.js
@@ -79,6 +79,7 @@ export class Tutorial
         let previous = document.createElement("button");
         previous.innerHTML = "Previous";
         let progress = document.createElement('p');
+        progress.setAttribute("id", "tutorial-progress");
         progress.innerHTML = tutorialPageIndex + 1 + "/16";
 
         next.addEventListener("click", () =>


### PR DESCRIPTION
Users can now move a selected layer up and down with hotkeys instead of drag-and-drop if desired.