### PR TITLE
Decrement the layerIdCounter when deleting a layer

### DIFF
--- a/source/pixel.js
+++ b/source/pixel.js
@@ -658,6 +658,8 @@ export default class PixelPlugin
         //refreshing the layers view to reflect changes
         this.uiManager.createPluginElements(this.layers);
         this.redrawAllLayers();
+
+        this.layerIdCounter--;
     }
 
     createLayer ()


### PR DESCRIPTION
When creating a new layer after deleting one, have the layerId be the immediate next available ID instead of incrementing forever 