### PR TITLE
Check and disable create/destroy layer functions and buttons

### DIFF
--- a/source/ui-manager.js
+++ b/source/ui-manager.js
@@ -25,8 +25,11 @@ export class UIManager
         this.placeLayerCanvasesInDiva(layers);
         this.createUndoButton();
         this.createRedoButton();
-        this.createDeleteLayerButton();
-        this.createCreateLayerButton();
+        // Disable buttons if in standalone Pixel or no input layers
+        if (typeof numberInputLayers === 'undefined' || numberInputLayers === 0) {
+            this.createDeleteLayerButton();
+            this.createCreateLayerButton();
+        }
         this.createLayersView(layers);
         this.createToolsView(this.pixelInstance.tools.getAllTools());
         this.createExportButtons();
@@ -39,8 +42,11 @@ export class UIManager
         this.destroyBrushSizeSelector();
         this.destroyUndoButton();
         this.destroyRedoButton();
-        this.destroyDeleteLayerButton();
-        this.destroyCreateLayerButton();
+        // Disable buttons if in standalone Pixel or no input layers
+        if (typeof numberInputLayers === 'undefined' || numberInputLayers === 0) {
+            this.destroyDeleteLayerButton();
+            this.destroyCreateLayerButton();
+        }
         this.destroyExportButtons();
         this.destroyImportButtons();
         this.destroyPixelCanvases(layers);
@@ -459,6 +465,11 @@ export class UIManager
 
     createDeleteLayerButton ()
     {
+        // Check if we're in the wrapper, if so then disable this function
+        if (document.getElementById("rodan-export-button") !== null) {
+            return;
+        }
+
         let deleteLayerButton = document.createElement("button"),
             text = document.createTextNode("Delete selected layer");
 
@@ -486,12 +497,22 @@ export class UIManager
 
     destroyDeleteLayerButton ()
     {
+        // Check if we're in the wrapper, if so then disable this function
+        if (document.getElementById("rodan-export-button") !== null) {
+            return;
+        }
+
         let deleteLayerButton = document.getElementById("delete-layer-button");
         deleteLayerButton.parentNode.removeChild(deleteLayerButton);
     }
 
     createCreateLayerButton ()
     {
+        // Check if we're in the wrapper, if so then disable this function
+        if (document.getElementById("rodan-export-button") !== null) {
+            return;
+        }
+
         let createLayerButton = document.createElement("button"),
             text = document.createTextNode("Create new layer");
 
@@ -506,6 +527,11 @@ export class UIManager
 
     destroyCreateLayerButton ()
     {
+        // Check if we're in the wrapper, if so then disable this function
+        if (document.getElementById("rodan-export-button") !== null) {
+            return;
+        }
+
         let createLayerButton = document.getElementById("create-layer-button");
         createLayerButton.parentNode.removeChild(createLayerButton);
     }


### PR DESCRIPTION
This check was recommended to be put in the standalone Pixel.js (it doesn't remove any compatibility with the standalone, and is cleaner to implement here than in the wrapper).

Only disable the buttons if either in standalone Pixel.js, or if the number of input layers is 0. This check is short-circuited if in the standalone Pixel.js and numberInputLayers doesn't exist.

Functions are disabled if the `submitToRodan` button exists (`!== null`), so it will function normally in the standalone Pixel.js.

Function disables are required because layers can be created/deleted with hotkeys as well.