### PR TITLE
Add case for layer being 'Select Region' (from wrapper) when drawing rectangle

### DIFF
--- a/source/rectangle.js
+++ b/source/rectangle.js
@@ -128,9 +128,16 @@ export class Rectangle extends Shape
         // TODO: Use padded coordinates
         else if (this.blendMode === "add")
         {
-            if (pageIndex === this.origin.pageIndex)
+            if (pageIndex === this.origin.pageIndex && layer.layerId === -1) // "Select Region" layer 
             {
-                //Draw the rectangle
+                // Draw the rectangle with a border
+                ctx.fillStyle = layer.colour.toHTMLColour();
+                ctx.lineWidth = 1;
+                ctx.strokeStyle = 'rgba(0, 0, 0, 1)';
+                ctx.fillRect(absoluteRectOriginX, absoluteRectOriginY, absoluteRectWidth, absoluteRectHeight);
+                ctx.strokeRect(absoluteRectOriginX, absoluteRectOriginY, absoluteRectWidth, absoluteRectHeight);
+            } else if (pageIndex === this.origin.pageIndex) { 
+                // Draw rectangle without border
                 ctx.fillStyle = layer.colour.toHTMLColour();
                 ctx.fillRect(absoluteRectOriginX, absoluteRectOriginY,absoluteRectWidth,absoluteRectHeight);
             }

--- a/source/tools.js
+++ b/source/tools.js
@@ -40,6 +40,9 @@ export class Tools
             case this.type.erase:
                 this.pixelInstance.uiManager.destroyBrushCursor();
                 break;
+            case this.type.rectangle:
+                this.pixelInstance.uiManager.destroyBrushCursor();
+                break;
             default:
                 break;
         }


### PR DESCRIPTION
Doesn't affect the standalone Pixel, but if `Select Region` layer exists (created in the wrapper), then draw rectangles with border.

Also add case for startup tool being rectangle