### PR TITLE
Update for latest Diva v6 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,40 +6,36 @@
 - Label every pixel of the image with its corresponding class (background, staff lines, text, etc...). This will be used to provide the ground truth data for the machine learning algorithm that classifies and isolates the different components of old manuscripts and scores.
 
 ## Prerequisites
-The following is a list of prerequisites that are necessary to run [```Diva.js```](https://github.com/DDMAL/diva.js) (and thus Pixel.js). The script in the quick start section is intended to install them as well as build and run pixel.
+The following is a list of prerequisites that are necessary to run [```Diva.js```](https://github.com/DDMAL/diva.js) (and thus Pixel.js).
 - [Node.js](https://github.com/nodesource/distributions#debinstall) v8.0.0 or higher
 - [npm](https://www.npmjs.com/get-npm) v5.0.0 or higher
 - [webpack](https://webpack.js.org/guides/installation/) v3.0.0 or higher
-- [gulp](https://www.npmjs.com/package/gulp)
 
-- Download [```Diva.js v.6.0```](https://github.com/DDMAL/diva.js/tree/develop-diva6) and [```Pixel.js```](https://github.com/DDMAL/Pixel.js/tree/develop). Be aware that Pixel.js will only work with Diva.js v6.0, so please ensure that is the version used before proceeding.
+- Download [```Diva.js v.6.0```](https://github.com/DDMAL/diva.js/tree/develop) and [```Pixel.js```](https://github.com/DDMAL/Pixel.js/tree/develop). Be aware that Pixel.js will only work with Diva.js v6.0, so please ensure that is the version used before proceeding.
 - If necessary, rename the pixel folder to ```Pixel.js``` and place the entire folder into `diva.js/source/js/plugins`
 - In `diva.js/webpack.config.js` you should find the list of plugins included in the Diva build like the following:
-
     ``` js
-    plugins: (process.env.NODE_ENV === "production") ? productionPlugins() : developmentPlugins()
-    }, {
-        entry: {
-            'download': './source/js/plugins/download.js',
-            'manipulation': './source/js/plugins/manipulation.js'
-        }
+    entry: {
+        'download': './source/js/plugins/download.js',
+        'manipulation': './source/js/plugins/manipulation.js',
+        'metadata': './source/js/plugins/metadata.js'
+    }
     ```
 - Include the path to ```pixel.js``` file to the list of plugins your plugins entry should look like the following
     ``` js
     entry: {
-            'pixel': './source/js/plugins/Pixel.js/source/pixel.js',
-            'download': './source/js/plugins/download.js',
-            'manipulation': './source/js/plugins/manipulation.js'
-        }
+        'download': './source/js/plugins/download.js',
+        'metadata': './source/js/plugins/metadata.js',
+        'manipulation': './source/js/plugins/manipulation.js',
+        'pixel': './source/js/plugins/Pixel.js/source/pixel.js'
+    }   
     ```
 
 ## Quick Start
-- In the ```Pixel.js``` directory, run the `pixel.sh` script using the following command. (This will install the dependencies, build and run Diva with the pixel plugin instantiated).
-    ```bash
-    $ ./pixel.sh
-    ``` 
-- By the end of the script, You might get a JSHint error. This is okay, Diva should be running on ```http://localhost:9001/``` 
-- You can now start using Pixel by pressing on the pixel plugin icon on top of a page (black square)
+- After the prerequisite steps are completed, you should be in the `diva.js/` directory.
+- Install [Node.js](https://nodejs.org/en/download/).
+- Navigate to `source/js/plugins/Pixel.js/`, and run `./pixel.sh`. 
+- Diva and Pixel should now be running at `http://localhost:9001`.  
 
 ## Alternative Start
 ### Instantiating Pixel.js
@@ -48,19 +44,19 @@ The following is a list of prerequisites that are necessary to run [```Diva.js``
     <script src="build/plugins/pixel.js"></script>
     ```
 - When instantiating diva, include `Diva.PixelPlugin` to the list of plugins. Your diva instantiation should like something like the following: (Take a look at the Example section for a full HTML example)
-    ``` js
+    ```javascript
     var diva = new Diva('diva-wrapper', {
-                    objectData: "https://images.simssa.ca/iiif/manuscripts/cdn-hsmu-m2149l4/manifest.json",
-                    plugins: [Diva.DownloadPlugin, Diva.ManipulationPlugin, Diva.PixelPlugin]
-                });
+        objectData: "https://images.simssa.ca/iiif/manuscripts/cdn-hsmu-m2149l4/manifest.json",
+        plugins: [Diva.DownloadPlugin, Diva.ManipulationPlugin, Diva.MetadataPlugin, Diva.PixelPlugin]
+    });
     ```
 
 ### Running Diva.js
-- To run diva, make sure that all the prerequisites are met then run the following commands
+- To run diva, make sure that all the prerequisites are met then run the following commands (from the root directory)
     ```bash
     $ npm install 
-    $ npm install -g gulp webpack
-    $ gulp
+    $ npm run build:production
+    $ cp ./source/js/plugins/Pixel.js/pixel.css ./build
+    $ python -m SimpleHTTPServer 9001
     ```
-- Copy `diva.css` from `diva.js/source/css/` to `build/css/` (if it is not already there)
 - Diva and Pixel.js are now running on ```http://localhost:9001/``` and you can now start using Pixel by pressing on the pixel plugin icon on top of a page (black square)

--- a/index.html
+++ b/index.html
@@ -6,22 +6,23 @@
     <meta name="viewport"
           content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <link rel="stylesheet" href="source/js/plugins/Pixel.js/pixel.css"/>
-    <link rel="stylesheet" href="build/css/diva.css"/>
+    <link rel="stylesheet" href="build/pixel.css"/>
+    <link rel="stylesheet" href="build/diva.css"/>
     <title>Pixel.js</title>
 </head>
 <body>
 <div id="diva-wrapper"></div>
-<script src="/assets/diva.js"></script>
+<script src="build/diva.js"></script>
 <script src="build/plugins/download.js"></script>
 <script src="build/plugins/manipulation.js"></script>
+<script src="build/plugins/metadata.js"></script>
 <script src="build/plugins/pixel.js"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function ()
     {
         var diva = new Diva('diva-wrapper', {
             objectData: "https://images.simssa.ca/iiif/manuscripts/cdn-hsmu-m2149l4/manifest.json",
-            plugins: [Diva.DownloadPlugin, Diva.ManipulationPlugin, Diva.PixelPlugin]
+            plugins: [Diva.DownloadPlugin, Diva.ManipulationPlugin, Diva.MetadataPlugin, Diva.PixelPlugin]
         });
     }, false)
 </script>

--- a/pixel.sh
+++ b/pixel.sh
@@ -1,100 +1,16 @@
-#!/bin/sh
-
-OS=$(uname -s)
-
-scp ./index.html ../../../../
-
 cd ../../../../
 
-
-if [ $OS = "Linux" ]
-then
-
-read -p "Building this project requires npm, gulp and webpack. This script will install what's missing. Would you like to install them? [y/n]" INSTALL
-
-if [ "$INSTALL" = "y" ]
-then
-
-if ! type npm > /dev/null;
-then
-echo "> Installing npm"
-sudo apt-get install nodejs
-sudo apt-get install npm
-sudo ln -s /usr/bin/nodejs /usr/bin/node
-fi
-
-if ! type webpack > /dev/null;
-then
-echo "> Installing webpack"
-sudo npm install --save-dev webpack
-fi
-
-if ! type gulp > /dev/null;
-then
-echo "> Installing gulp"
-sudo npm install -g gulp
-sudo npm install gulp
-fi
-
+# Install modules
 echo "> npm install"
-sudo npm install
-echo "> npm install -g gulp webpack"
-sudo npm install -g gulp webpack
+npm i
 
-fi
+# Create build directory with compiled source
+echo "> npm run build:production"
+npm run build:production
 
-elif [ $OS = "Darwin" ]
-then
-read -p "Building this project requires npm, gulp and webpack. You can install these with homebrew. This script will install what's missing. Would you like to install them? [y/n]" INSTALL
+# Copy CSS and index files to proper locations
+scp ./source/js/plugins/Pixel.js/index.html ./
+scp ./source/js/plugins/Pixel.js/pixel.css ./build
 
-if [ "$INSTALL" = "y" ]
-then
-
-if ! type brew > /dev/null;
-then
-echo "> Installing brew"
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-fi
-
-if ! type npm > /dev/null;
-then
-echo "> Installing npm"
-brew install npm
-fi
-
-if ! type webpack > /dev/null;
-then
-echo "> Installing webpack"
-brew install webpack
-fi
-
-if ! type gulp > /dev/null;
-then
-echo "> Installing gulp"
-brew install gulp
-fi  # end gulp
-
-echo "> npm install"
-sudo npm install
-echo "> npm install -g gulp webpack"
-sudo npm install -g gulp webpack
-
-fi  # end install
-fi  # end OS
-
-# Mandatory installation of the newest stable version of npm
-sudo npm install -g npm
-sudo npm install -g n
-sudo n stable
-
-mkdir build
-mkdir build/css
-echo "> scp ./source/css/diva.css ./build/css/"
-scp ./source/css/diva.css ./build/css/
-
-read -p "Build and run on http://localhost:9001/ (You might get a JSHint failed message, that should be ok, Diva will be still running)? [y/n] " RUN
-if [ "$RUN" = "y" ]
-then
-echo "> gulp"
-gulp
-fi
+# Start server
+python -m SimpleHTTPServer 9001

--- a/source/layer.js
+++ b/source/layer.js
@@ -18,7 +18,7 @@ export class Layer
         this.activated = true;
         this.layerOpacity = layerOpacity;
         this.pixelInstance = pixelInstance;
-        this.pageIndex = this.pixelInstance.core.getSettings().currentPageIndex;
+        this.pageIndex = this.pixelInstance.core.getSettings().activePageIndex;
         this.backgroundImageCanvas = null;
         this.pastedRegions = [];
         this.cloneCanvas();

--- a/source/pixel.js
+++ b/source/pixel.js
@@ -838,11 +838,11 @@ export default class PixelPlugin
             return;
 
         // Drawing on another page
-        if (this.core.getSettings().currentPageIndex !== this.layers[0].pageIndex)
+        if (this.core.getSettings().activePageIndex !== this.layers[0].pageIndex)
             return;
 
         // Get settings under the current zoomLevel
-        let pageIndex = this.core.getSettings().currentPageIndex,
+        let pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().zoomLevel,
             renderer = this.core.getSettings().renderer,
             relativeCoords = new Point().getRelativeCoordinatesFromPadded(pageIndex, renderer, mousePos.x, mousePos.y, zoomLevel);
@@ -891,14 +891,14 @@ export default class PixelPlugin
             return;
 
         // Drawing on another page
-        if (this.core.getSettings().currentPageIndex !== this.layers[0].pageIndex)
+        if (this.core.getSettings().activePageIndex !== this.layers[0].pageIndex)
             return;
 
         if (!this.mousePressed)
             return;
 
         let point,
-            pageIndex = this.core.getSettings().currentPageIndex,
+            pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().zoomLevel,
             renderer = this.core.getSettings().renderer,
             relativeCoords = new Point().getRelativeCoordinatesFromPadded(pageIndex, renderer, mousePos.x, mousePos.y, zoomLevel);
@@ -908,7 +908,7 @@ export default class PixelPlugin
 
         if (!this.layerChangedMidDraw)
         {
-            let pageIndex = this.core.getSettings().currentPageIndex,
+            let pageIndex = this.core.getSettings().activePageIndex,
                 zoomLevel = this.core.getSettings().maxZoomLevel;
 
             // Draw straight lines
@@ -973,10 +973,10 @@ export default class PixelPlugin
             return;
 
         // Drawing on another page
-        if (this.core.getSettings().currentPageIndex !== this.layers[0].pageIndex)
+        if (this.core.getSettings().activePageIndex !== this.layers[0].pageIndex)
             return;
 
-        let pageIndex = this.core.getSettings().currentPageIndex,
+        let pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().zoomLevel,
             renderer = this.core.getSettings().renderer,
             relativeCoords = new Point().getRelativeCoordinatesFromPadded(pageIndex, renderer, mousePos.x, mousePos.y, zoomLevel);
@@ -1016,7 +1016,7 @@ export default class PixelPlugin
             return;
 
         // Drawing on another page
-        if (this.core.getSettings().currentPageIndex !== this.layers[0].pageIndex)
+        if (this.core.getSettings().activePageIndex !== this.layers[0].pageIndex)
             return;
 
         if (!this.layerChangedMidDraw)
@@ -1024,7 +1024,7 @@ export default class PixelPlugin
             if (!this.mousePressed)
                 return;
 
-            let pageIndex = this.core.getSettings().currentPageIndex,
+            let pageIndex = this.core.getSettings().activePageIndex,
                 zoomLevel = this.core.getSettings().zoomLevel,
                 renderer = this.core.getSettings().renderer,
                 relativeCoords = new Point().getRelativeCoordinatesFromPadded(pageIndex, renderer, mousePos.x, mousePos.y, zoomLevel),
@@ -1140,7 +1140,7 @@ export default class PixelPlugin
     exportAsImageData ()
     {
         //FIXME: Force Diva to highest zoom level to be able to get the pixel data
-        let pageIndex = this.core.getSettings().currentPageIndex,
+        let pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().zoomLevel;
 
         new Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).exportLayersAsImageData();
@@ -1148,7 +1148,7 @@ export default class PixelPlugin
 
     exportAsPNG ()
     {
-        let pageIndex = this.core.getSettings().currentPageIndex,
+        let pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().zoomLevel;
 
         new Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).exportLayersAsPNG();
@@ -1156,7 +1156,7 @@ export default class PixelPlugin
 
     exportAsCSV ()
     {
-        let pageIndex = this.core.getSettings().currentPageIndex,
+        let pageIndex = this.core.getSettings().activePageIndex,
             zoomLevel = this.core.getSettings().maxZoomLevel;
 
         new Export(this, this.layers, pageIndex, zoomLevel, this.uiManager).exportLayersAsCSV();
@@ -1169,7 +1169,7 @@ export default class PixelPlugin
      **/
     importPNGToLayer (e)
     {
-        new Import(this, this.layers, this.core.getSettings().currentPageIndex, this.core.getSettings().zoomLevel, this.uiManager).uploadLocalImageToLayer(this.layers[this.selectedLayerIndex], e);
+        new Import(this, this.layers, this.core.getSettings().activePageIndex, this.core.getSettings().zoomLevel, this.uiManager).uploadLocalImageToLayer(this.layers[this.selectedLayerIndex], e);
     }
 }
 

--- a/source/ui-manager.js
+++ b/source/ui-manager.js
@@ -855,7 +855,7 @@ export class UIManager
 
     isInPageBounds (relativeX, relativeY)
     {
-        let pageIndex = this.pixelInstance.core.getSettings().currentPageIndex,
+        let pageIndex = this.pixelInstance.core.getSettings().activePageIndex,
             zoomLevel = this.pixelInstance.core.getSettings().zoomLevel,
             renderer  = this.pixelInstance.core.getSettings().renderer;
 


### PR DESCRIPTION
Latest diva6 removes gulp in favour of just webpack and npm scripts, as well as recent changes breaking some of the script.

I had lots of permissions errors with the scripts also (I think cause of doing `sudo npm install`) which are removed with these changes (in general everything is simpler, but the user is forced to install node themselves instead of being done automatically)