### PR TITLE
Fix broken gif links

### DIFF
--- a/source/tutorial.js
+++ b/source/tutorial.js
@@ -132,7 +132,7 @@ export class Tutorial
                 break;
             case 9:
                 tutorialP.innerHTML = "Use the Fullscreen mode <kbd>f</kbd> and the browser zoom to get more precision, when needed. <br> To exit Fullscreen mode, press on <kbd>f</kbd> again.";
-                img.src = "https://media.giphy.com/media/FkzOAenUJxfGg/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/fullscreen.gif";
                 break;
             case 10:
                 tutorialP.innerHTML = "You can bring a layer forward/backward by clicking and dragging them to their desired position.<br>You can also use <kbd>[</kbd> and <kbd>]</kbd> to move a selected layer down or up.";
@@ -140,11 +140,11 @@ export class Tutorial
                 break;
             case 11:
                 tutorialP.innerHTML = "You can undo <kbd>Ctrl</kbd> + <kbd>z</kbd> and redo <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>z</kbd> an action.";
-                img.src = "https://media.giphy.com/media/24kHpWLzbHFrq/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/undo_redo.gif";
                 break;
             case 12:
                 tutorialP.innerHTML = "You can delete a layer by selecting it and then using <kbd>Ctrl</kbd> + <kbd>del</kbd>.";
-                img.src = "https://media.giphy.com/media/cmQesBkeEvdmM/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/delete_layer.gif";
                 break;
             case 13:
                 tutorialP.innerHTML = "You can mute (press <kbd>m</kbd> to toggle on/off) or hide (hold <kbd>h</kbd> to turn off, release to turn on) layers.";
@@ -156,7 +156,7 @@ export class Tutorial
                 break;
             case 15:
                 tutorialP.innerHTML = "Export layers as PNGs to save a specific layer as an image. See the " + '<a href="https://github.com/DDMAL/Pixel.js/wiki">wiki</a>' + " for details on the different export buttons and more information.";
-                img.src = "https://media.giphy.com/media/kBAau6Gebio7e/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/21_export.gif";
                 break;
         }
 

--- a/source/tutorial.js
+++ b/source/tutorial.js
@@ -96,39 +96,39 @@ export class Tutorial
         {
             case 0:
                 tutorialP.innerHTML = "Welcome to Pixel.js, this is a tutorial that serves as a reminder of the available tools. <br>For a complete, detailed tutorial, visit the " + '<a href="https://github.com/DDMAL/Pixel.js/wiki/How-to-use-Pixel.js">Full Tutorial Page</a>' + " (right-click -> Open Link in New Tab). <br><br>Click on Got It! to exit this tutorial.";
-                img.src = "https://media.giphy.com/media/aL9oQ0f1sDIpq/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/01.gif";
                 break;
             case 1:
                 tutorialP.innerHTML = "Each layer has its own specific colour and represents a classification category. Create as many layers as needed. <br> A collection of keyboard shortcuts have been implemented. Each layer can be selected by its number (from <kbd>1</kbd> to <kbd>9</kbd>). Hover over the layers to receive a prompt.";
-                img.src = "https://media.giphy.com/media/rBiuWy5YUsIow/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/02.gif";
                 break;
             case 2:
                 tutorialP.innerHTML = "You can upload images to the currently selected layer. The image will be converted to the specified layer's colour. <br> In this example, we have uploaded the output images of a classification method in order to correct it.";
-                img.src = "https://media.giphy.com/media/Qy4u6oHru8OpG/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/03.gif";
                 break;
             case 3:
                 tutorialP.innerHTML = "Double click on the layer's name to rename it.";
-                img.src = "https://media.giphy.com/media/LRxzQa1ogqKAw/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/04.gif";
                 break;
             case 4:
                 tutorialP.innerHTML = "Use zoom along with the grab tool <kbd>g</kbd> to navigate a page.";
-                img.src = "https://media.giphy.com/media/hcLjZ9dFHOKDm/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/06.gif";
                 break;
             case 5:
                 tutorialP.innerHTML = "Use the select tool <kbd>s</kbd> to copy <kbd>Ctrl</kbd> + <kbd>c</kbd> or cut <kbd>Ctrl</kbd> + <kbd>x</kbd> and paste <kbd>Ctrl</kbd> + <kbd>v</kbd> rectangular regions of pixels from one layer to another.";
-                img.src = "https://media.giphy.com/media/ruMD98axGjdyE/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/07.gif";
                 break;
             case 6:
                 tutorialP.innerHTML = "Right-click and drag right and left on the erase <kbd>e</kbd> and brush <kbd>b</kbd> tools to change the brush size.";
-                img.src = "https://media.giphy.com/media/NhvALG9MhGYta/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/09.gif";
                 break;
             case 7:
                 tutorialP.innerHTML = "Press <kbd>Shift</kbd> and drag on the erase <kbd>e</kbd> and brush <kbd>b</kbd> tools to draw straight lines.";
-                img.src = "https://media.giphy.com/media/t74TeR1gd9aaA/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/10.gif";
                 break;
             case 8:
                 tutorialP.innerHTML = "Right-click and drag on rectangle tool <kbd>r</kbd> to erase rectangular regions, left-click to draw rectangle. Press <kbd>Shift</kbd> to draw squares.";
-                img.src = "https://media.giphy.com/media/i497rUNYB8t32/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/08.gif";
                 break;
             case 9:
                 tutorialP.innerHTML = "Use the Fullscreen mode <kbd>f</kbd> and the browser zoom to get more precision, when needed. <br> To exit Fullscreen mode, press on <kbd>f</kbd> again.";
@@ -136,7 +136,7 @@ export class Tutorial
                 break;
             case 10:
                 tutorialP.innerHTML = "You can bring a layer forward/backward by clicking and dragging them to their desired position.<br>You can also use <kbd>[</kbd> and <kbd>]</kbd> to move a selected layer down or up.";
-                img.src = "https://media.giphy.com/media/DImPhyGZ3OltC/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/11.gif";
                 break;
             case 11:
                 tutorialP.innerHTML = "You can undo <kbd>Ctrl</kbd> + <kbd>z</kbd> and redo <kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>z</kbd> an action.";
@@ -148,11 +148,11 @@ export class Tutorial
                 break;
             case 13:
                 tutorialP.innerHTML = "You can mute (press <kbd>m</kbd> to toggle on/off) or hide (hold <kbd>h</kbd> to turn off, release to turn on) layers.";
-                img.src = "https://media.giphy.com/media/BhVXr7ONVdStq/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/12_layers_on_off.gif";
                 break;
             case 14:
                 tutorialP.innerHTML = "Change the opacity of a layer by displaying the layer options.";
-                img.src = "https://media.giphy.com/media/94EtnDoG2yNAQ/giphy.gif";
+                img.src = "https://github.com/DDMAL/Pixel.js/wiki/assets/05.gif";
                 break;
             case 15:
                 tutorialP.innerHTML = "Export layers as PNGs to save a specific layer as an image. See the " + '<a href="https://github.com/DDMAL/Pixel.js/wiki">wiki</a>' + " for details on the different export buttons and more information.";


### PR DESCRIPTION
Since the gifs that were used within Pixel.js and in the wiki seem to be gone from giphy, what we still had were added to the wiki under an `assets` folder. Some new gifs had to be generated and while they look different from the others, they should work. These commits link to the gifs in the wiki.

Resolves #255.