### PR TITLE
Allow unlimited pasting

### DIFF
--- a/source/pixel.js
+++ b/source/pixel.js
@@ -447,7 +447,6 @@ export default class PixelPlugin
                         if (this.selection.imageData !== null)
                         {
                             this.selection.pasteShapeToLayer(this.layers[this.selectedLayerIndex]);
-                            this.selection = null;
                             this.redrawLayer(this.layers[this.selectedLayerIndex]);
                         }
                     }


### PR DESCRIPTION
_Resolves #189_

- No longer clear selection after pasting so that the user can undo and re-paste onto another layer if they make a mistake