### PR TITLE
fix users being able to bypass selecting background region

### DIFF
--- a/source/pixel.js
+++ b/source/pixel.js
@@ -665,6 +665,16 @@ export default class PixelPlugin
             case this.tools.type.grab:
                 mouseClickDiv.style.cursor = "-webkit-grab";
                 break;
+            case this.tools.type.select:
+                if(this.selection !== null && this.selection.selectedShape !== null) {
+                    let rectangle = this.selection.selectedShape;
+                    //if the rectangle has 0 area, then the user just clicked and should be
+                    //interpreted as a command to remove the current selection
+                    if(rectangle.relativeRectHeight === 0 && rectangle.relativeRectWidth === 0) {
+                        this.selection.clearSelection(this.core.getSettings().maxZoomLevel);
+                    }
+                }                
+                break;
             default:
         }
     }


### PR DESCRIPTION
Address bug raised in this [issue](https://github.com/DDMAL/Pixel.js/issues/265).

We thought the users could bypass selecting a background region before submitting to rodan. The actual issue that when users click on the screen, it looks as though the selection box is being deleting. This is not the case. Instead, a 1x1 selection box is created that is too small to see.

The mouse up logic has been changed to delete the select box if it has 0 area.